### PR TITLE
Make compatible with PyTorch 0.4 and Volta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ IF (CUDA_VERSION GREATER 7.6)
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_62,code=sm_62")
 ENDIF()
 
+IF (CUDA_VERSION GREATER 8.9)
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_70,code=sm_70")
+ENDIF()
+
 if (NOT APPLE)
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --std=c++11")
     set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -fopenmp")

--- a/pytorch_binding/src/_warpctc.cpp
+++ b/pytorch_binding/src/_warpctc.cpp
@@ -7,7 +7,7 @@
 
 #include <torch/torch.h>
 #include <ATen/TensorUtils.h>
-#include <ATen/ATenAssert.h>
+#include <ATen/Error.h>
 #include <tuple>
 #include <iostream>
 #include "ctc.h"
@@ -84,7 +84,7 @@ ctcStatus_t get_workspace_size(const int* const label_lengths,
 				options, &workspace_size);
 
     if (status != CTC_STATUS_SUCCESS) {
-       at::runtime_error(ctcGetStatusString(status));
+       AT_ERROR(ctcGetStatusString(status));
     }
    
     at::Tensor workspace = activations.type().toScalarType(at::kByte).tensor(workspace_size);
@@ -103,7 +103,7 @@ ctcStatus_t get_workspace_size(const int* const label_lengths,
 			      workspace.data_ptr(), options);
 
     if (status != CTC_STATUS_SUCCESS) {
-       at::runtime_error(ctcGetStatusString(status));
+       AT_ERROR(ctcGetStatusString(status));
     }
     return std::make_tuple(costs, gradients);
 

--- a/pytorch_binding/tests/test.py
+++ b/pytorch_binding/tests/test.py
@@ -130,6 +130,7 @@ class TestWarpCTC(unittest.TestCase):
                         msg="gradient of inf cost should not be NaN")
 
     def grad_test(self, cuda=False):
+        device = torch.device("cuda:0" if cuda else "cpu")
         problem_sizes = [[20, 50, 15, 1, 10**(-2.5)],
                          [5, 10, 5, 65, 1e-2]]
         # n.b. warpctc's c++ cpu tests use squared relative difference
@@ -137,8 +138,8 @@ class TestWarpCTC(unittest.TestCase):
         for alphabet_size, seq_len, label_len, minibatch, tol in problem_sizes:
             acts = torch.rand(seq_len, minibatch, alphabet_size,
                               requires_grad=True,
-                              dtype=(torch.cuda.float32 if cuda
-                                     else torch.float32))
+                              dtype=torch.float32,
+                              device=device)
             sizes = torch.IntTensor(minibatch).fill_(seq_len)
             label_lengths = torch.IntTensor(minibatch).fill_(label_len)
             labels = torch.IntTensor(label_len,

--- a/pytorch_binding/warpctc/__init__.py
+++ b/pytorch_binding/warpctc/__init__.py
@@ -40,7 +40,7 @@ class CTCFunction(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_out):
         # check whether grad_in is zero
-        gradients, = ctx.saved_variables
+        gradients, = ctx.saved_tensors
         if gradients.is_cuda:
             grad_out = grad_out.cuda(device=gradients.get_device())
         gradients = gradients * grad_out.view(1, -1, 1)


### PR DESCRIPTION
Fix the bindings to work with the released version of PyTorch 0.4 and add compute capability 7.0 for volta cards.